### PR TITLE
feat: add argument for custom version table generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- `rails generate paper_trail:install` now accepts an argument for custom versions table, e.g.
+  `rails generate paper_trail:install CommentVersion` created `comment_versions` table
+- `rails generate paper_trail:update_item_subtype` now supports custom version classes via 
+  `--version-class-name` option, e.g. `--version-class-name=CommentVersion`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,8 @@ Be advised that redefining an association is an undocumented feature of Rails.
 PaperTrail has one generator, `paper_trail:install`. It writes, but does not
 run, a migration file. The migration creates the `versions` table.
 
+You can provide a custom version table name e.g., for having multiple version tables. You will still need setup a custom Version class and configure it to use the custom table. See [6.a. Custom Version Classes](#6a-custom-version-classes).
+
 #### Reference
 
 The most up-to-date documentation for this generator can be found by running
@@ -1162,19 +1164,25 @@ convenience.
 
 ```
 Usage:
-  rails generate paper_trail:install [options]
+  bin/rails generate paper_trail:install [VERSION_CLASS_NAME] [options]
 
 Options:
-  [--with-changes], [--no-with-changes]            # Store changeset (diff) with each version
-  [--uuid]                                         # To use paper_trail with projects using uuid for id
+  [--skip-namespace]                                            # Skip namespace (affects only isolated engines)
+                                                                # Default: false
+  [--skip-collision-check]                                      # Skip collision check
+                                                                # Default: false
+  [--with-changes], [--no-with-changes], [--skip-with-changes]  # Store changeset (diff) with each version
+                                                                # Default: false
+  [--uuid], [--no-uuid], [--skip-uuid]                          # Use uuid instead of bigint for item_id type (use only if tables use UUIDs)
+                                                                # Default: false
 
 Runtime options:
-  -f, [--force]                    # Overwrite files that already exist
-  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
-  -q, [--quiet], [--no-quiet]      # Suppress status output
-  -s, [--skip], [--no-skip]        # Skip files that already exist
+  -f, [--force]                                      # Overwrite files that already exist
+  -p, [--pretend], [--no-pretend], [--skip-pretend]  # Run but do not make any changes
+  -q, [--quiet], [--no-quiet], [--skip-quiet]        # Suppress status output
+  -s, [--skip], [--no-skip], [--skip-skip]           # Skip files that already exist
 
-Generates (but does not run) a migration to add a versions table.
+Generates (but does not run) a migration to add a versions table. Can be customized by providing a Version class name. See section 5.c. Generators in README.md for more information.
 ```
 
 ### 5.d. Protected Attributes

--- a/lib/generators/paper_trail/install/USAGE
+++ b/lib/generators/paper_trail/install/USAGE
@@ -1,3 +1,31 @@
 Description:
   Generates (but does not run) a migration to add a versions table. Also generates an initializer
-  file for configuring PaperTrail. See section 5.c. Generators in README.md for more information.
+  file for configuring PaperTrail. Can be customized by providing a Version class name.
+  See section 5.c. Generators in README.md for more information.
+
+Examples:
+  rails generate paper_trail:install
+
+  This will create:
+    db/migrate/[TIMESTAMP]_create_versions.rb
+    config/initializers/paper_trail.rb
+
+  rails generate paper_trail:install --with-changes
+
+  This will create:
+    db/migrate/[TIMESTAMP]_create_versions.rb
+    db/migrate/[TIMESTAMP]_add_object_changes_to_versions.rb
+    config/initializers/paper_trail.rb
+
+  rails generate paper_trail:install CommentVersion
+
+  This will create:
+    db/migrate/[TIMESTAMP]_create_comment_versions.rb
+    config/initializers/paper_trail.rb
+
+  rails generate paper_trail:install ProductVersion --with-changes --uuid
+
+  This will create:
+    db/migrate/[TIMESTAMP]_create_product_versions.rb
+    db/migrate/[TIMESTAMP]_add_object_changes_to_product_versions.rb
+    config/initializers/paper_trail.rb

--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -27,19 +27,21 @@ module PaperTrail
       desc: "Use uuid instead of bigint for item_id type (use only if tables use UUIDs)"
     )
 
-    desc "Generates (but does not run) a migration to add a versions table.  " \
+    desc "Generates (but does not run) a migration to add a versions table. " \
+         "Can be customized by providing a Version class name. " \
          "See section 5.c. Generators in README.md for more information."
 
     def create_migration_file
+      # Use the table_name to create the proper migration filename
       add_paper_trail_migration(
-        "create_versions",
+        "create_#{table_name}",
         item_type_options: item_type_options,
         versions_table_options: versions_table_options,
         item_id_type_options: item_id_type_options,
         version_table_primary_key_type: version_table_primary_key_type
       )
       if options.with_changes?
-        add_paper_trail_migration("add_object_changes_to_versions")
+        add_paper_trail_migration("add_object_changes_to_#{table_name}")
       end
     end
 

--- a/lib/generators/paper_trail/install/templates/add_object_changes_to_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/add_object_changes_to_versions.rb.erb
@@ -1,12 +1,12 @@
 # This migration adds the optional `object_changes` column, in which PaperTrail
 # will store the `changes` diff for each update event. See the readme for
 # details.
-class AddObjectChangesToVersions < ActiveRecord::Migration<%= migration_version %>
+class AddObjectChangesTo<%= version_class_name.pluralize %> < ActiveRecord::Migration<%= migration_version %>
   # The largest text column available in all supported RDBMS.
   # See `create_versions.rb` for details.
   TEXT_BYTES = 1_073_741_823
 
   def change
-    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+    add_column :<%= table_name %>, :object_changes, :text, limit: TEXT_BYTES
   end
 end

--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -1,6 +1,6 @@
-# This migration creates the `versions` table, the only schema PT requires.
+# This migration creates the `<%= table_name %>` table for the <%= version_class_name %> class.
 # All other migrations PT provides are optional.
-class CreateVersions < ActiveRecord::Migration<%= migration_version %>
+class Create<%= version_class_name.pluralize %> < ActiveRecord::Migration<%= migration_version %>
 
   # The largest text column available in all supported RDBMS is
   # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
@@ -9,7 +9,7 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
   TEXT_BYTES = 1_073_741_823
 
   def change
-    create_table :versions<%= versions_table_options %><%= version_table_primary_key_type %> do |t|
+    create_table :<%= table_name %><%= versions_table_options %><%= version_table_primary_key_type %> do |t|
       # Consider using bigint type for performance if you are going to store only numeric ids.
       # t.bigint   :whodunnit
       t.string   :whodunnit
@@ -36,6 +36,6 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
       t.string   :event,     null: false
       t.text     :object, limit: TEXT_BYTES
     end
-    add_index :versions, %i[item_type item_id]
+    add_index :<%= table_name %>, %i[item_type item_id]
   end
 end

--- a/lib/generators/paper_trail/migration_generator.rb
+++ b/lib/generators/paper_trail/migration_generator.rb
@@ -8,6 +8,10 @@ module PaperTrail
   class MigrationGenerator < ::Rails::Generators::Base
     include ::Rails::Generators::Migration
 
+    # Define arguments for the generator
+    argument :version_class_name, type: :string, default: "Version",
+      desc: "The name of the Version class (e.g., CommentVersion)"
+
     def self.next_migration_number(dirname)
       ::ActiveRecord::Generators::Base.next_migration_number(dirname)
     end
@@ -19,10 +23,17 @@ module PaperTrail
       if self.class.migration_exists?(migration_dir, template)
         ::Kernel.warn "Migration already exists: #{template}"
       else
+        # Map the dynamic template name to the actual template file
+        template_file = map_template_name(template)
+
         migration_template(
-          "#{template}.rb.erb",
+          "#{template_file}.rb.erb",
           "db/migrate/#{template}.rb",
-          { migration_version: migration_version }.merge(extra_options)
+          {
+            migration_version: migration_version,
+            table_name: table_name,
+            version_class_name: version_class_name
+          }.merge(extra_options)
         )
       end
     end
@@ -33,6 +44,22 @@ module PaperTrail
         ActiveRecord::VERSION::MAJOR,
         ActiveRecord::VERSION::MINOR
       )
+    end
+
+    # Convert Version class name to table name using Rails conventions
+    def table_name
+      version_class_name.underscore.pluralize
+    end
+
+    # Map the dynamic template name to the actual template file
+    def map_template_name(template)
+      if template.start_with?("create_")
+        "create_versions"
+      elsif template.start_with?("add_object_changes_to_")
+        "add_object_changes_to_versions"
+      else
+        template
+      end
     end
   end
 end

--- a/lib/generators/paper_trail/update_item_subtype/templates/update_versions_for_item_subtype.rb.erb
+++ b/lib/generators/paper_trail/update_item_subtype/templates/update_versions_for_item_subtype.rb.erb
@@ -1,6 +1,6 @@
 # This migration updates existing `versions` that have `item_type` that refers to
 # the base_class, and changes them to refer to the subclass instead.
-class UpdateVersionsForItemSubtype < ActiveRecord::Migration<%= migration_version %>
+class Update<%= version_class_name.pluralize %>ForItemSubtype < ActiveRecord::Migration<%= migration_version %>
   include ActionView::Helpers::TextHelper
   def up
 <%=
@@ -18,7 +18,8 @@ class UpdateVersionsForItemSubtype < ActiveRecord::Migration<%= migration_versio
   #   # Versions of item_type "Plant" with IDs between 42 and 1337 will be updated based on `genus`
   #   hints = {"Animal"=>{1..4=>"species"}, "Plant"=>{42..1337=>"genus"}}
   hint_descriptions = ""
-  hints = args.inject(Hash.new{|h, k| h[k] = {}}) do |s, v|
+  # Use @hints over args to not break the test itself since args could now include --version_class_name=CommentVersion
+  hints = (@hints || []).inject(Hash.new{|h, k| h[k] = {}}) do |s, v|
     klass, column, range = parse_custom_entry(v)
     hint_descriptions << "    # Versions of item_type \"#{klass}\" with IDs between #{
       range.first} and #{range.last} will be updated based on \`#{column}\`\n"
@@ -32,7 +33,7 @@ class UpdateVersionsForItemSubtype < ActiveRecord::Migration<%= migration_versio
 %>
     # Find all ActiveRecord models mentioned in existing versions
     changes = Hash.new { |h, k| h[k] = [] }
-    model_names = PaperTrail::Version.select(:item_type).distinct
+    model_names = <%= fully_qualified_version_class_name %>.select(:item_type).distinct
     model_names.map(&:item_type).each do |model_name|
       hint = hints[model_name] if defined?(hints)
       begin
@@ -40,7 +41,7 @@ class UpdateVersionsForItemSubtype < ActiveRecord::Migration<%= migration_versio
         # Actually implements an inheritance_column?  (Usually "type")
         has_inheritance_column = klass.columns.map(&:name).include?(klass.inheritance_column)
         # Find domain of types stored in PaperTrail versions
-        PaperTrail::Version.where(item_type: model_name, item_subtype: nil).select(:id, :object, :object_changes).each do |obj|
+        <%= fully_qualified_version_class_name %>.where(item_type: model_name, item_subtype: nil).select(:id, :object, :object_changes).each do |obj|
           if (object_detail = PaperTrail.serializer.load(obj.object || obj.object_changes))
             is_found = false
             subtype_name = nil
@@ -72,11 +73,11 @@ class UpdateVersionsForItemSubtype < ActiveRecord::Migration<%= migration_versio
       v.sort.each do |id|
         block_of_ids << id
         if (id_count += 1) % 100 == 0
-          num_updated += PaperTrail::Version.where(id: block_of_ids).update_all(item_subtype: k)
+          num_updated += <%= fully_qualified_version_class_name %>.where(id: block_of_ids).update_all(item_subtype: k)
           block_of_ids = []
         end
       end
-      num_updated += PaperTrail::Version.where(id: block_of_ids).update_all(item_subtype: k)
+      num_updated += <%= fully_qualified_version_class_name %>.where(id: block_of_ids).update_all(item_subtype: k)
       if num_updated > 0
         say "Associated #{pluralize(num_updated, 'record')} to #{k}", subitem: true
       end

--- a/lib/generators/paper_trail/update_item_subtype/update_item_subtype_generator.rb
+++ b/lib/generators/paper_trail/update_item_subtype/update_item_subtype_generator.rb
@@ -7,13 +7,34 @@ module PaperTrail
   class UpdateItemSubtypeGenerator < MigrationGenerator
     source_root File.expand_path("templates", __dir__)
 
+    # Remove the inherited version_class_name argument as we use an option instead
+    remove_argument :version_class_name
+
+    argument :hints, type: :array, default: [], banner: "hint1 hint2"
+
+    class_option :version_class_name,
+      type: :string,
+      default: "Version",
+      aliases: ["-v"],
+      desc: "The name of the Version class (e.g., CommentVersion)"
+
     desc(
       "Generates (but does not run) a migration to update item_subtype for " \
       "STI entries in an existing versions table."
     )
 
     def create_migration_file
-      add_paper_trail_migration("update_versions_for_item_subtype", sti_type_options: options)
+      add_paper_trail_migration("update_#{table_name}_for_item_subtype", sti_type_options: options)
+    end
+
+    # Return the version class name from options
+    def version_class_name
+      options[:version_class_name]
+    end
+
+    # Return the fully qualified class name for use in ERB templates
+    def fully_qualified_version_class_name
+      version_class_name == "Version" ? "PaperTrail::Version" : version_class_name
     end
   end
 end

--- a/spec/dummy_app/app/versions/abstract_version.rb
+++ b/spec/dummy_app/app/versions/abstract_version.rb
@@ -2,5 +2,6 @@
 
 class AbstractVersion < ApplicationRecord
   include PaperTrail::VersionConcern
+
   self.abstract_class = true
 end

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -6,6 +6,7 @@ require "generators/paper_trail/install/install_generator"
 
 RSpec.describe PaperTrail::InstallGenerator, type: :generator do
   include GeneratorSpec::TestCase
+
   destination File.expand_path("tmp", __dir__)
 
   after do
@@ -132,6 +133,84 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
             directory("migrate") {
               migration("create_versions") {
                 contains ", id: :#{expected_primary_key_type}"
+              }
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "with custom version class name" do
+    before do
+      prepare_destination
+      run_generator %w[CommentVersion]
+    end
+
+    it "generates a migration with the correct filename and content for the custom table" do
+      expected_parent_class = lambda {
+        old_school = "ActiveRecord::Migration"
+        ar_version = ActiveRecord::VERSION
+        format("%s[%d.%d]", old_school, ar_version::MAJOR, ar_version::MINOR)
+      }.call
+
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("create_comment_versions") {
+                contains("class CreateCommentVersions < " + expected_parent_class)
+                contains "def change"
+                contains "create_table :comment_versions"
+                contains "add_index :comment_versions, %i[item_type item_id]"
+              }
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "with custom version class name and `--with-changes`" do
+    before do
+      prepare_destination
+      run_generator %w[ProductVersion --with-changes]
+    end
+
+    it "generates migrations with correct filenames and content for the custom table" do
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("create_product_versions") {
+                contains "class CreateProductVersions"
+                contains "create_table :product_versions"
+              }
+              migration("add_object_changes_to_product_versions") {
+                contains "class AddObjectChangesToProductVersions"
+                contains "add_column :product_versions, :object_changes, :text"
+              }
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "with namespaced custom version class" do
+    before do
+      prepare_destination
+      run_generator %w[CommentVersion]
+    end
+
+    it "handles namespaced class names correctly with proper filenames" do
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("create_comment_versions") {
+                contains "class CreateCommentVersions"
+                contains "create_table :comment_versions"
               }
             }
           }


### PR DESCRIPTION
This change lets you provide a custom version table name e.g., for having multiple version tables.
You can now run `rails generate paper_trail:install CommentVersion` to generate a `comment_versions` table.

This change does:
- add argument to install generator
- add option to the update item subtype generator to support custom version class names
- add test for the filenames of the migration

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
